### PR TITLE
Fix missing `BSDIFF_API` on `bsdiff_open_bz2_patch_packer`

### DIFF
--- a/include/bsdiff.h
+++ b/include/bsdiff.h
@@ -192,6 +192,7 @@ struct bsdiff_patch_packer
  * @return
  *    BSDIFF_SUCCESS if no error.
  */
+BSDIFF_API
 int bsdiff_open_bz2_patch_packer(
 	int mode,
 	struct bsdiff_stream *stream,


### PR DESCRIPTION
This caused `bsdiff_open_bz2_patch_packer` to be an undefined reference/unresolved external when using bsdiff as a shared library. The problem originated from the inadvertent removal of `BSDIFF_API` in https://github.com/zhuyie/bsdiff/commit/c8b45970633611e0ec3a94cb6fd1bb8cd12ee72d#diff-0a430e1c0cfcedc6792ea5aeed7571ed7998640f9baa83e4e41d17ce1a4418e5L137